### PR TITLE
[processor/routing] Properly create  new pdata instances

### DIFF
--- a/.chloggen/26464-routingprocessor-fix.yaml
+++ b/.chloggen/26464-routingprocessor-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/routing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When using attributes instead of resource attributes, the routing processor would crash the collector. This does not affect the connector version of this component.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26462]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -106,8 +106,8 @@ func (p *tracesProcessor) route(ctx context.Context, t ptrace.Traces) error {
 	for i := 0; i < t.ResourceSpans().Len(); i++ {
 		rspans := t.ResourceSpans().At(i)
 		stx := ottlspan.NewTransformContext(
-			ptrace.Span{},
-			pcommon.InstrumentationScope{},
+			ptrace.NewSpan(),
+			pcommon.NewInstrumentationScope(),
 			rspans.Resource(),
 		)
 

--- a/processor/routingprocessor/traces_test.go
+++ b/processor/routingprocessor/traces_test.go
@@ -457,7 +457,9 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 	})
 }
 
+// see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26462
 func TestAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
+	// prepare
 	defaultExp := &mockTracesExporter{}
 	firstExp := &mockTracesExporter{}
 
@@ -486,8 +488,12 @@ func TestAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 	span.SetName("span")
 
 	require.NoError(t, exp.Start(context.Background(), host))
+
+	// test
+	// before #26464, this would panic
 	require.NoError(t, exp.ConsumeTraces(context.Background(), tr))
 
+	// verify
 	assert.Len(t, defaultExp.AllTraces(), 1)
 	assert.Len(t, firstExp.AllTraces(), 0)
 


### PR DESCRIPTION
This PR changes the routing processor so that it properly creates new instances of pdata.Span and InstrumentationScope, avoiding crashes later on due to nil pointers.

Fixes #26462

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>